### PR TITLE
tethering: Do not override DUN in shipping builds

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -63,8 +63,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.build.selinux=1
 
+ifneq ($(TARGET_BUILD_VARIANT),user)
 # Thank you, please drive thru!
 PRODUCT_PROPERTY_OVERRIDES += persist.sys.dun.override=0
+endif
 
 ifneq ($(TARGET_BUILD_VARIANT),eng)
 # Enable ADB authentication


### PR DESCRIPTION
This was done for one specific carrier, and is breaking most others
that rely on DUN profiles. Don't.

Addresses CYNGNOS-999

Change-Id: I42fbbabfc87001bcec0c9978e33b999de8d5aecd
