### PR TITLE
Add libcore.net.MimeUtils Overrides

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -110,6 +110,10 @@ PRODUCT_COPY_FILES +=  \
     vendor/cm/prebuilt/common/media/LMprec_508.emd:system/media/LMprec_508.emd \
     vendor/cm/prebuilt/common/media/PFFprec_600.emd:system/media/PFFprec_600.emd
 
+# Copy over added mimetype supported in libcore.net.MimeUtils
+PRODUCT_COPY_FILES += \
+    vendor/cm/prebuilt/common/lib/content-types.properties:system/lib/content-types.properties
+
 # Enable SIP+VoIP on all targets
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.software.sip.voip.xml:system/etc/permissions/android.software.sip.voip.xml

--- a/prebuilt/common/lib/content-types.properties
+++ b/prebuilt/common/lib/content-types.properties
@@ -1,0 +1,8 @@
+# If you want to support more recognized mimetypes in libcore.net.MimeUtils, add them here
+
+docm=application/vnd.ms-word.document.macroenabled.12
+xlsb=application/vnd.ms-excel.sheet.binary.macroEnabled.12
+xlsm=application/vnd.ms-excel.sheet.macroEnabled.12
+ppsm=application/vnd.ms-powerpoint.slideshow.macroEnabled.12
+ppsx=application/vnd.openxmlformats-officedocument.presentationml.slideshow
+pptm=application/vnd.ms-powerpoint.presentation.macroEnabled.12


### PR DESCRIPTION
This will allow us to add supported mimetypes in libcore.net.MimeUtils
which in turn will allow more recognized mimetypes for anything that
uses android.webkit.MimeTypeMap.

Change-Id: I97febe17cff1d196f479b557fef3bca1b11bdd74
Issue-Id: CYNGNOS-1176
