### PR TITLE
sepolicy: qcom: Remove duplicate entry

### DIFF
--- a/sepolicy/qcom/perfd.te
+++ b/sepolicy/qcom/perfd.te
@@ -1,5 +1,4 @@
 allow perfd sysfs_devices_system_iosched:file rw_file_perms;
-unix_socket_connect(perfd, thermal, thermal-engine)
 
 # read mediaserver status
 allow perfd mediaserver:file { read open };


### PR DESCRIPTION
We have this in qcom/sepolicy/common already.

Change-Id: Ibe6ada531f77d3ec00ff61081d21b3d36a1fe7a7
