### PR TITLE
backuptool: Use cut instead of awk

### DIFF
--- a/prebuilt/common/bin/backuptool.sh
+++ b/prebuilt/common/bin/backuptool.sh
@@ -45,7 +45,7 @@ check_blacklist() {
       ## Discard any known bad backup scripts
       cd /$1/addon.d/
       for f in *sh; do
-          s=$(md5sum $f | awk {'print $1'})
+          s=$(md5sum $f | cut -c-32)
           grep -q $s /system/addon.d/blacklist && rm -f $f
       done
   fi
@@ -57,7 +57,7 @@ check_whitelist() {
       ## forcefully keep any version-independent stuff
       cd /$1/addon.d/
       for f in *sh; do
-          s=$(md5sum $f | awk {'print $1'})
+          s=$(md5sum $f | cut -c-32)
           grep -q $s /system/addon.d/whitelist
           if [ $? -eq 0 ]; then
               found=1


### PR DESCRIPTION
recovery has removed busybox in favor of toybox, and toybox does not
currently implement awk.

Change-Id: I9d91f52020e8a7b5b02dce27f3d82e6bf0aa1811
