### PR TITLE
sepolicy: Rule for CM's perfd extension

### DIFF
--- a/sepolicy/qcom/perfd.te
+++ b/sepolicy/qcom/perfd.te
@@ -3,3 +3,5 @@ allow perfd sysfs_devices_system_iosched:file rw_file_perms;
 # read mediaserver status
 allow perfd mediaserver:file { read open };
 
+#cm extra opts
+unix_socket_connect(perfd, thermal, thermal-engine)


### PR DESCRIPTION
Manual apply and refactor of cm-12.1 patch:
e04329df88211264e7a9c8f1d6b87a16d8d5639b

Use the unix_socket_connect macro and switch to the new
perfd domain.

Change-Id: Ibb83220b32bad7805653140751c978e629f87ffb
