### PR TITLE
sepolicy: Allow adb pull of executables without root

### DIFF
--- a/sepolicy/qcom/adbd.c
+++ b/sepolicy/qcom/adbd.c
@@ -1,0 +1,14 @@
+# Allow pulling various binaries without root
+# (cause we're awesome like that)
+
+allow adbd adsprpcd_exec:file r_file_perms;
+allow adbd location_exec:file r_file_perms;
+allow adbd mm-qcamerad_exec:file r_file_perms;
+allow adbd mpdecision_exec:file r_file_perms;
+allow adbd perfd_exec:file r_file_perms;
+allow adbd rfs_access_exec:file r_file_perms;
+allow adbd rmt_storage_exec:file r_file_perms;
+allow adbd sensors_exec:file r_file_perms;
+allow adbd tee_exec:file r_file_perms;
+allow adbd thermal-engine_exec:file r_file_perms;
+allow adbd time_daemon_exec:file r_file_perms;


### PR DESCRIPTION
- Because we aren't actually jerks, contrary to popular belief.

Change-Id: Ie39cce65ecc6a2861547865ff554b108b8b534fa
