### PR TITLE
Correct Tele2 Sweden APNs and remove Comviq Sweden.

### DIFF
--- a/prebuilt/common/etc/apns-conf.xml
+++ b/prebuilt/common/etc/apns-conf.xml
@@ -797,19 +797,13 @@
   <apn carrier="3 SE MMS" mcc="240" mnc="02" apn="data.tre.se" mmsc="http://mms.tre.se" mmsproxy="mmsproxy.tre.se" mmsport="8799" type="mms" />
   <apn carrier="Telenor Mobilsurf" mcc="240" mnc="04" apn="services.telenor.se" proxy="172.30.253.241" port="8799" user="" password="" mmsc="" type="default,supl" />
   <apn carrier="Telenor MMS" mcc="240" mnc="04" apn="services.telenor.se" proxy="" port="" user="" password="" mmsc="http://mms" mmsproxy="172.30.253.241" mmsport="8799" type="mms" />
-  <apn carrier="Comviq" mcc="240" mnc="05" apn="internet.tele2.se" user="" password="" authtype="1" type="default,supl" spn="Comviq" />
-  <apn carrier="Comviq MMS" mcc="240" mnc="05" apn="internet.tele2.se" proxy="" port="" mmsproxy="130.244.202.30" mmsport="8080" mmsc="http://mmsc.tele2.se" user="" password="" authtype="1" type="mms" spn="Comviq" />
   <apn carrier="Telenor MMS" mcc="240" mnc="06" apn="services.telenor.se" proxy="" port="" user="" password="" mmsc="http://mms" mmsproxy="173.30.253.241" mmsport="8799" type="mms" />
   <apn carrier="Telenor Mobilsurf" mcc="240" mnc="06" apn="services.telenor.se" proxy="173.30.253.241" port="8799" user="" password="" mmsc="" type="default,supl" />
   <apn carrier="Glocalnet Internet" mcc="240" mnc="06" apn="internet.glocalnet.se" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
   <apn carrier="Glocalnet MMS" mcc="240" mnc="06" apn="services.glocalnet.se" proxy="" port="" user="" password="" mmsc="http://mms" mmsproxy="172.30.253.241" mmsport="8799" type="mms" />
   <apn carrier="Glocalnet WAP GPRS" mcc="240" mnc="06" apn="services.glocalnet.se" proxy="172.30.253.241" port="8799" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="Comviq" mcc="240" mnc="07" apn="internet.tele2.se" user="" password="" authtype="1" type="default,supl" spn="Comviq" />
-  <apn carrier="Comviq MMS" mcc="240" mnc="07" apn="internet.tele2.se" proxy="" port="" mmsproxy="130.244.202.30" mmsport="8080" mmsc="http://mmsc.tele2.se" user="" password="" authtype="1" type="mms" spn="Comviq" />
-  <apn carrier="Tele2 4G" mcc="240" mnc="07" apn="4g.tele2.se" mmsc="http://mmsc.tele2.se" mmsproxy="130.244.202.30" mmsport="8080" authtype="2" type="default,mms" />
-  <apn carrier="Tele2" mcc="240" mnc="07" apn="mobileinternet.tele2.se" mmsc="http://mmsc.tele2.se" mmsproxy="130.244.202.30" mmsport="8080" authtype="2" type="default,supl,mms" />
-  <apn carrier="Tele2 SE" mcc="240" mnc="07" apn="internet.tele2.se" user="wap" password="wap" mmsc="http://mmsc.tele2.se" mmsproxy="130.244.202.030" mmsport="8080" type="default,supl,mms" />
-  <apn carrier="Tele2 3G" mcc="240" mnc="07" apn="internet.tele2.se" mmsc="http://mmsc.tele2.se" mmsproxy="130.244.202.30" mmsport="8080" type="default,supl,mms" />
+  <apn carrier="Tele2 Internet" mcc="240" mnc="07" apn="4g.tele2.se" type="default,supl" />
+  <apn carrier="Tele2 MMS" mcc="240" mnc="07" apn="4g.tele2.se" mmsc="http://mmsc.tele2.se" mmsproxy="130.244.202.30" mmsport="8080" type="mms" />
   <apn carrier="Tele2 Internet" mcc="240" mnc="07" apn="internet.tele2.no" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
   <apn carrier="Tele2 MMS" mcc="240" mnc="07" apn="internet.tele2.no" proxy="" port="" user="" password="" mmsc="http://mmsc.tele2.no" mmsproxy="193.12.40.14" mmsport="8080" type="mms" />
   <apn carrier="Spring data" mcc="240" mnc="07" apn="data.springmobil.se" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
@@ -845,8 +839,6 @@
   <apn carrier="Talkmore" mcc="242" mnc="01" apn="telenor" type="default,supl,mms" />
   <apn carrier="Phonero Internett" mcc="242" mnc="01" apn="internet.phonero.no" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
   <apn carrier="Phonero MMS" mcc="242" mnc="01" apn="mms.phonero.no" proxy="" port="" user="phonero" password="1111" mmsc="http://mmsc" mmsproxy="10.10.10.11" mmsport="8080" type="mms" />
-  <apn carrier="Tele2 Internet" mcc="242" mnc="01" apn="internet.tele2.se" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
-  <apn carrier="Tele2 MMS" mcc="242" mnc="01" apn="internet.tele2.se" proxy="" port="" user="" password="" mmsc="http://mmsc.tele2.se" mmsproxy="130.244.202.30" mmsport="8080" type="mms" />
   <apn carrier="TDC MMS" mcc="242" mnc="01" apn="mms.no" proxy="" port="" user="" password="" mmsc="http://mms.tdcmobil.no:8002" mmsproxy="194.182.251.15" mmsport="8080" type="mms" />
   <apn carrier="TDC Internet" mcc="242" mnc="01" apn="internet.no" proxy="" port="" user="" password="" mmsc="" type="default,supl" />
   <apn carrier="TDC WAP" mcc="242" mnc="01" apn="internet.no" proxy="194.182.251.15" port="8080" user="" password="" mmsc="" type="default,supl" />


### PR DESCRIPTION
Tele2 is the parent company of Comviq and it's operating in Tele2s network,
hence using the same APNs as Tele2

Change-Id: I55c551827a6312159cfdd8c01e20e5e1d3016cdf
