### PR TITLE
cm: Include librsjni explicitly

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -135,6 +135,10 @@ PRODUCT_PACKAGES += \
     libemoji \
     Terminal
 
+# Include librsjni explicitly to workaround GMS issue
+PRODUCT_PACKAGES += \
+    librsjni
+
 # Custom CM packages
 PRODUCT_PACKAGES += \
     Launcher3 \


### PR DESCRIPTION
- Make sure this gets included since GMS webview breaks the dependency.

Change-Id: I49b01309dce8d9779ca58576c2d7ee78d133ddb0
